### PR TITLE
Improve BaseEncoding formatter and always set Formatter for NTHierarchyNode

### DIFF
--- a/ext/src/main/java/org/chromattic/ext/ntdef/NTHierarchyNode.java
+++ b/ext/src/main/java/org/chromattic/ext/ntdef/NTHierarchyNode.java
@@ -18,10 +18,12 @@
  */
 package org.chromattic.ext.ntdef;
 
+import org.chromattic.api.annotations.FormattedBy;
 import org.chromattic.api.annotations.ManyToOne;
 import org.chromattic.api.annotations.Name;
 import org.chromattic.api.annotations.PrimaryType;
 import org.chromattic.api.annotations.Property;
+import org.chromattic.ext.format.BaseEncodingObjectFormatter;
 
 import java.util.Date;
 
@@ -30,6 +32,7 @@ import java.util.Date;
  * @version $Revision$
  */
 @PrimaryType(name = "nt:hierarchyNode")
+@FormattedBy(BaseEncodingObjectFormatter.class)
 public abstract class NTHierarchyNode {
 
   @Name

--- a/ext/src/test/java/org/chromattic/ext/format/BaseEncodingObjectFormatterTestCase.java
+++ b/ext/src/test/java/org/chromattic/ext/format/BaseEncodingObjectFormatterTestCase.java
@@ -35,40 +35,30 @@ public class BaseEncodingObjectFormatterTestCase extends TestCase {
   /** . */
   private final ObjectFormatter formatter = new BaseEncodingObjectFormatter();
 
-  private void assertString(String expected, String s) {
+  private void assertEscapeString(String expected, String s) {
     assertEquals(expected, formatter.encodeNodeName(null, s));
     assertEquals(s, formatter.decodeNodeName(null, expected));
   }
 
-  private void assertCannotDecode(String s) {
-    try {
-      formatter.decodeNodeName(null, s);
-      fail();
-    }
-    catch (IllegalStateException ignore) {
-    }
-  }
-
   public void testStrings() {
-    assertString("", "");
-    assertString("a", "a");
-    assertString("%00", "{");
-    assertString("%01", "}");
-    assertString("%02", ".");
-    assertString("%03", "/");
-    assertString("%04", ":");
-    assertString("%05", "[");
-    assertString("%06", "]");
-    assertString("%07", "|");
-    assertString("%08", "*");
-    assertString("%09", "%");
-    assertString("a%03b", "a/b");
-  }
-
-  public void testDecodeFailure() {
-    assertCannotDecode("%0");
-    assertCannotDecode("%0" + (char)('0' - 1));
-    assertCannotDecode("%0" + (char)('9' + 1));
-    assertCannotDecode("%1");
+    assertEscapeString("", "");
+    assertEscapeString("a", "a");
+    assertEscapeString("%3A", ":");
+    assertEscapeString("%7C", "|");
+    assertEscapeString("%5B", "[");
+    assertEscapeString("%5D", "]");
+    assertEscapeString("%2F", "/");
+    assertEscapeString("%2A", "*");
+    assertEscapeString("%25", "%");
+    assertEscapeString("%27", "'");
+    assertEscapeString("%22", "\"");
+    assertEscapeString("%09", "\t");
+    assertEscapeString("%0A", "\n");
+    assertEscapeString("%0D", "\r");
+    assertEscapeString("%20test", " test");
+    assertEscapeString("test%20", "test ");
+    assertEscapeString("%20test value%20", " test value ");
+    assertEscapeString("%2Ed", ".d");
+    assertEscapeString("a%2Fb", "a/b");
   }
 }

--- a/ext/src/test/java/org/chromattic/ext/ntdef/NTHierarchyTestCase.java
+++ b/ext/src/test/java/org/chromattic/ext/ntdef/NTHierarchyTestCase.java
@@ -65,6 +65,16 @@ public class NTHierarchyTestCase extends TestCase {
     session.save();
   }
 
+  public void testSpecialNTFolder() {
+    String specialName = "folder{s %test[1]";
+    ChromatticSession session = chromattic.openSession();
+    NTFolder folder = session.insert(NTFolder.class, "parentfolder");
+    NTFolder specialFolder = folder.createFolder(specialName);
+    assertNotNull(specialFolder);
+    assertEquals(specialName, specialFolder.getName());
+    session.save();
+  }
+
   public void testNTFile() throws Exception {
     ChromatticSession session = chromattic.openSession();  
     NTFile file = session.insert(NTFile.class, "file");


### PR DESCRIPTION
- BaseEncodingObjectFormatter should be based on JCR encoding, the legacy Formatter was missing several encoding characters, and encoded value is not suitable with JCR name value
- NTHierarchyNode must be formatted by Base Encoding Object Formatter
